### PR TITLE
chore: Setup publishing on release creation

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -1,0 +1,31 @@
+name: Trigger Snapshot Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish_archives:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+
+      - name: Setup gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-home-cache-cleanup: true
+
+      - name: Verify build
+        run: ./gradlew check
+
+      - name: Publish the artifacts
+        run: ./gradlew publishPlugins --no-configuration-cache
+        env:
+          GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+          GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Trigger Release
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  publish_archives:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    env:
+      RELEASE: true
+
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+
+      - name: Setup gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-home-cache-cleanup: true
+
+      - name: Verify build
+        run: ./gradlew check
+
+      - name: Publish the artifacts
+        run: ./gradlew publishPlugins --no-configuration-cache
+        env:
+          GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+          GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}

--- a/build-targets-gradle-plugin/build.gradle.kts
+++ b/build-targets-gradle-plugin/build.gradle.kts
@@ -8,6 +8,23 @@ plugins {
 group = "com.faire.gradle"
 version = "0.0.0"
 
+if (!providers.environmentVariable("RELEASE").isPresent) {
+  val gitSha = providers.environmentVariable("GITHUB_SHA")
+    .orElse(
+      provider {
+        // nest the provider, we don't want to invalidate the config cache for this
+        providers.exec { commandLine("git", "rev-parse", "--short", "HEAD") }
+          .standardOutput
+          .asText
+          .map { it.trim() }
+          .get()
+      },
+    )
+    .get()
+
+  version = "$version-$gitSha-SNAPSHOT"
+}
+
 dependencies {
   api(kotlin("stdlib"))
 


### PR DESCRIPTION
This sets up publishing of releases when a release is created in github. Most of this was cribbed from https://github.com/Faire/faire-detekt-rules/blob/cb7c9d831c3b93de49db75c8bc8fd4f95192ed03/.github/workflows/release.yml\#L14 and updated for this repo's use-case.