### PR TITLE
feat: Add source path exclusions

### DIFF
--- a/build-targets-gradle-plugin/build.gradle.kts
+++ b/build-targets-gradle-plugin/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.faire"
-version = "0.0.0"
+version = "0.0.1"
 
 dependencies {
   api(kotlin("stdlib"))

--- a/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ComputeSourceFoldersTask.kt
+++ b/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ComputeSourceFoldersTask.kt
@@ -51,7 +51,7 @@ internal abstract class ComputeSourceFoldersTask @Inject constructor(
       .convention(
           project.rootProject.the<ShowBuildTargetsForChangeExtension>().sourceSetPathExcludePatterns.map { patterns ->
             patterns.map { Regex(it) }.toSet()
-          }
+          },
       )
 
   @OutputFile

--- a/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ComputeSourceFoldersTask.kt
+++ b/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ComputeSourceFoldersTask.kt
@@ -29,38 +29,38 @@ import javax.inject.Inject
  */
 @CacheableTask
 internal abstract class ComputeSourceFoldersTask @Inject constructor(
-  objects: ObjectFactory,
+    objects: ObjectFactory,
 ) : DefaultTask() {
 
   @Suppress("UNUSED") // This is an input to the task, acting as a proxy for figuring out source files.
   @InputFiles
   @PathSensitive(PathSensitivity.RELATIVE)
   val buildFiles: ConfigurableFileCollection = objects.fileCollection()
-    .from(
-      project.rootProject.layout.projectDirectory.asFileTree.filter {
-        it.name == "build.gradle.kts" &&
-            "/test/" !in it.path // exclude test projects
-      },
-    )
+      .from(
+          project.rootProject.layout.projectDirectory.asFileTree.filter {
+            it.name == "build.gradle.kts" &&
+                "/test/" !in it.path // exclude test projects
+          },
+      )
 
   /**
    * Patterns to use to exclude source files from consideration.
    */
   @Input
   internal val sourceSetPathExcludePatterns: SetProperty<Regex> = objects.setProperty<Regex>()
-    .convention(
-      project.rootProject.the<ShowBuildTargetsForChangeExtension>().sourceSetPathExcludePatterns.map { patterns ->
-        patterns.map { Regex(it) }.toSet()
-      }
-    )
+      .convention(
+          project.rootProject.the<ShowBuildTargetsForChangeExtension>().sourceSetPathExcludePatterns.map { patterns ->
+            patterns.map { Regex(it) }.toSet()
+          }
+      )
 
   @OutputFile
   val jsonFile: RegularFileProperty = objects.fileProperty()
-    .convention(project.layout.buildDirectory.file("faire-release/sourceFolders.json"))
+      .convention(project.layout.buildDirectory.file("faire-release/sourceFolders.json"))
 
   @Internal
   val rootProjectDirectory: DirectoryProperty = objects.directoryProperty()
-    .convention(project.rootProject.layout.projectDirectory)
+      .convention(project.rootProject.layout.projectDirectory)
 
   // Done this way to avoid using this in the implementation, making it configuration-cache safe.
   // If this is too slow in the future, we can consider making this task run _per project_ and do a map-reduce
@@ -68,15 +68,15 @@ internal abstract class ComputeSourceFoldersTask @Inject constructor(
   // parallelize this, letting it run "faster" in the future.
   @Input
   val projectToSourceDirectories: MapProperty<String, Set<File>> = objects.mapProperty<String, Set<File>>()
-    .value(
-      project.provider {
-        project.rootProject.subprojects.parallelStream()
-          .collect(Collectors.toMap({ it.path }, ::computeWatchedFiles))
-      },
-    )
-    .apply {
-      finalizeValueOnRead()
-    }
+      .value(
+          project.provider {
+            project.rootProject.subprojects.parallelStream()
+                .collect(Collectors.toMap({ it.path }, ::computeWatchedFiles))
+          },
+      )
+      .apply {
+        finalizeValueOnRead()
+      }
 
   @TaskAction
   fun execute() {
@@ -88,9 +88,9 @@ internal abstract class ComputeSourceFoldersTask @Inject constructor(
     val rootDirectory = rootProjectDirectory.asFile.get()
 
     val json = gson.toJson(
-      projectToSourceDirectories.get().mapValues { (_, files) ->
-        files.map { it.relativeTo(rootDirectory).path }
-      },
+        projectToSourceDirectories.get().mapValues { (_, files) ->
+          files.map { it.relativeTo(rootDirectory).path }
+        },
     )
 
     outputFile.writeText(json)
@@ -101,10 +101,10 @@ internal abstract class ComputeSourceFoldersTask @Inject constructor(
     // directories for source files to reduce the number of entries in this set.
     val buildDir = project.layout.buildDirectory.get().asFile.toPath()
     val sourceDirectories = project.the<JavaPluginExtension>().sourceSets
-      .asSequence()
-      .flatMap { it.allSource.sourceDirectories.files }
-      .filter { f -> !f.toPath().startsWith(buildDir) }
-      .filter { f -> !sourceSetPathExcludePatterns.get().any { f.path.matches(it) } }
+        .asSequence()
+        .flatMap { it.allSource.sourceDirectories.files }
+        .filter { f -> !f.toPath().startsWith(buildDir) }
+        .filter { f -> !sourceSetPathExcludePatterns.get().any { f.path.matches(it) } }
 
     val buildKts = project.layout.projectDirectory.file("build.gradle.kts").asFile
 

--- a/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ComputeSourceFoldersTask.kt
+++ b/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ComputeSourceFoldersTask.kt
@@ -8,6 +8,7 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
@@ -17,6 +18,7 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.mapProperty
+import org.gradle.kotlin.dsl.setProperty
 import org.gradle.kotlin.dsl.the
 import java.io.File
 import java.util.stream.Collectors
@@ -27,27 +29,38 @@ import javax.inject.Inject
  */
 @CacheableTask
 internal abstract class ComputeSourceFoldersTask @Inject constructor(
-    objects: ObjectFactory,
+  objects: ObjectFactory,
 ) : DefaultTask() {
 
   @Suppress("UNUSED") // This is an input to the task, acting as a proxy for figuring out source files.
   @InputFiles
   @PathSensitive(PathSensitivity.RELATIVE)
   val buildFiles: ConfigurableFileCollection = objects.fileCollection()
-      .from(
-          project.rootProject.layout.projectDirectory.asFileTree.filter {
-            it.name == "build.gradle.kts" &&
-                "/test/" !in it.path // exclude test projects
-          },
-      )
+    .from(
+      project.rootProject.layout.projectDirectory.asFileTree.filter {
+        it.name == "build.gradle.kts" &&
+            "/test/" !in it.path // exclude test projects
+      },
+    )
+
+  /**
+   * Patterns to use to exclude source files from consideration.
+   */
+  @Input
+  internal val sourceSetPathExcludePatterns: SetProperty<Regex> = objects.setProperty<Regex>()
+    .convention(
+      project.rootProject.the<ShowBuildTargetsForChangeExtension>().sourceSetPathExcludePatterns.map { patterns ->
+        patterns.map { Regex(it) }.toSet()
+      }
+    )
 
   @OutputFile
   val jsonFile: RegularFileProperty = objects.fileProperty()
-      .convention(project.layout.buildDirectory.file("faire-release/sourceFolders.json"))
+    .convention(project.layout.buildDirectory.file("faire-release/sourceFolders.json"))
 
   @Internal
   val rootProjectDirectory: DirectoryProperty = objects.directoryProperty()
-      .convention(project.rootProject.layout.projectDirectory)
+    .convention(project.rootProject.layout.projectDirectory)
 
   // Done this way to avoid using this in the implementation, making it configuration-cache safe.
   // If this is too slow in the future, we can consider making this task run _per project_ and do a map-reduce
@@ -55,15 +68,15 @@ internal abstract class ComputeSourceFoldersTask @Inject constructor(
   // parallelize this, letting it run "faster" in the future.
   @Input
   val projectToSourceDirectories: MapProperty<String, Set<File>> = objects.mapProperty<String, Set<File>>()
-      .value(
-          project.provider {
-            project.rootProject.subprojects.parallelStream()
-                .collect(Collectors.toMap({ it.path }, ::computeWatchedFiles))
-          },
-      )
-      .apply {
-        finalizeValueOnRead()
-      }
+    .value(
+      project.provider {
+        project.rootProject.subprojects.parallelStream()
+          .collect(Collectors.toMap({ it.path }, ::computeWatchedFiles))
+      },
+    )
+    .apply {
+      finalizeValueOnRead()
+    }
 
   @TaskAction
   fun execute() {
@@ -75,9 +88,9 @@ internal abstract class ComputeSourceFoldersTask @Inject constructor(
     val rootDirectory = rootProjectDirectory.asFile.get()
 
     val json = gson.toJson(
-        projectToSourceDirectories.get().mapValues { (_, files) ->
-          files.map { it.relativeTo(rootDirectory).path }
-        },
+      projectToSourceDirectories.get().mapValues { (_, files) ->
+        files.map { it.relativeTo(rootDirectory).path }
+      },
     )
 
     outputFile.writeText(json)
@@ -88,9 +101,10 @@ internal abstract class ComputeSourceFoldersTask @Inject constructor(
     // directories for source files to reduce the number of entries in this set.
     val buildDir = project.layout.buildDirectory.get().asFile.toPath()
     val sourceDirectories = project.the<JavaPluginExtension>().sourceSets
-        .asSequence()
-        .flatMap { it.allSource.sourceDirectories.files }
-        .filter { f -> !f.toPath().startsWith(buildDir) }
+      .asSequence()
+      .flatMap { it.allSource.sourceDirectories.files }
+      .filter { f -> !f.toPath().startsWith(buildDir) }
+      .filter { f -> !sourceSetPathExcludePatterns.get().any { f.path.matches(it) } }
 
     val buildKts = project.layout.projectDirectory.file("build.gradle.kts").asFile
 

--- a/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ComputeSourceFoldersTask.kt
+++ b/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ComputeSourceFoldersTask.kt
@@ -104,7 +104,7 @@ internal abstract class ComputeSourceFoldersTask @Inject constructor(
         .asSequence()
         .flatMap { it.allSource.sourceDirectories.files }
         .filter { f -> !f.toPath().startsWith(buildDir) }
-        .filter { f -> !sourceSetPathExcludePatterns.get().any { f.path.matches(it) } }
+        .filter { f -> sourceSetPathExcludePatterns.get().none { f.path.matches(it) } }
 
     val buildKts = project.layout.projectDirectory.file("build.gradle.kts").asFile
 

--- a/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ComputeSourceFoldersTask.kt
+++ b/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ComputeSourceFoldersTask.kt
@@ -47,7 +47,7 @@ internal abstract class ComputeSourceFoldersTask @Inject constructor(
    * Patterns to use to exclude source files from consideration.
    */
   @Input
-  internal val sourceSetPathExcludePatterns: SetProperty<Regex> = objects.setProperty<Regex>()
+  val sourceSetPathExcludePatterns: SetProperty<Regex> = objects.setProperty<Regex>()
       .convention(
           project.rootProject.the<ShowBuildTargetsForChangeExtension>().sourceSetPathExcludePatterns.map { patterns ->
             patterns.map { Regex(it) }.toSet()

--- a/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ShowBuildTargetsForChangeExtension.kt
+++ b/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ShowBuildTargetsForChangeExtension.kt
@@ -9,8 +9,8 @@ import javax.inject.Inject
  * Provides extensions for configuring the plugin.
  */
 open class ShowBuildTargetsForChangeExtension @Inject constructor(
-  objects: ObjectFactory,
-){
+    objects: ObjectFactory,
+) {
   /**
    * Regex patterns to **exclude** source set folders. If **any** pattern is matched, a source is excluded.
    *

--- a/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ShowBuildTargetsForChangeExtension.kt
+++ b/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ShowBuildTargetsForChangeExtension.kt
@@ -1,0 +1,20 @@
+package com.faire.gradle.release
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.SetProperty
+import org.gradle.kotlin.dsl.setProperty
+import javax.inject.Inject
+
+/**
+ * Provides extensions for configuring the plugin.
+ */
+open class ShowBuildTargetsForChangeExtension @Inject constructor(
+  objects: ObjectFactory,
+){
+  /**
+   * Regex patterns to **exclude** source set folders. If **any** pattern is matched, a source is excluded.
+   *
+   * Patterns are applied to the full path of the source sets.
+   */
+  val sourceSetPathExcludePatterns: SetProperty<String> = objects.setProperty()
+}

--- a/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ShowBuildTargetsForChangePlugin.kt
+++ b/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ShowBuildTargetsForChangePlugin.kt
@@ -6,6 +6,7 @@ package com.faire.gradle.release
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.assign
+import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.register
 import org.jetbrains.annotations.VisibleForTesting
@@ -41,6 +42,8 @@ class ShowBuildTargetsForChangePlugin : Plugin<Project> {
           projectDependencyPathsFile = computeRuntimeClasspathDependentProjects.flatMap { it.dependentProjectsListFile }
         }
       }
+    } else {
+      rootProject.extensions.create("showBuildTargets", ShowBuildTargetsForChangeExtension::class)
     }
   }
 

--- a/build-targets-gradle-plugin/src/test/kotlin/com/faire/gradle/release/ShowServiceChangePluginTest.kt
+++ b/build-targets-gradle-plugin/src/test/kotlin/com/faire/gradle/release/ShowServiceChangePluginTest.kt
@@ -246,16 +246,18 @@ internal class ShowServiceChangePluginTest {
           """
           
           showBuildTargets {
-            sourceExcludePatterns.add(".+/src/[\\w+\\-_]+/resources/?.*")
+            sourceSetPathExcludePatterns.add(".+/src/main/?.*")
           }
         """.trimIndent(),
       )
     }
 
+    gitCommitAll(root, "update root build")
+
     val initialResourcesHash = getCommitHash(root)
 
-    updateAndCommitNewResourcesToProject(root, "dependency-project")
-    updateAndCommitNewResourcesToProject(root, "dependency-project-2")
+    updateAndCommitNewFolderToProject(root, "main/kotlin", "dependency-project")
+    updateAndCommitNewFolderToProject(root, "main/kotlin", "dependency-project-2")
 
     val addedResourcesHash = getCommitHash(root)
 
@@ -324,6 +326,15 @@ internal class ShowServiceChangePluginTest {
     root.resolve("$project/src/main/resources").deleteRecursively()
 
     gitCommitAll(root, "'delete resources: $project'")
+  }
+
+  private fun updateAndCommitNewFolderToProject(root: File, folderName: String, project: String) {
+    with(root.resolve("$project/src/$folderName/test.txt")) {
+      parentFile.mkdirs()
+      writeText("Test file content")
+    }
+
+    gitCommitAll(root, "'change add resource: $project'")
   }
 
   private fun getCommitHash(root: File): String = git(root, "show-ref", "-s")

--- a/build-targets-gradle-plugin/src/test/kotlin/com/faire/gradle/release/ShowServiceChangePluginTest.kt
+++ b/build-targets-gradle-plugin/src/test/kotlin/com/faire/gradle/release/ShowServiceChangePluginTest.kt
@@ -248,7 +248,7 @@ internal class ShowServiceChangePluginTest {
           showBuildTargets {
             sourceExcludePatterns.add(".+/src/[\\w+\\-_]+/resources/?.*")
           }
-        """.trimIndent()
+        """.trimIndent(),
       )
     }
 

--- a/build-targets-gradle-plugin/src/test/kotlin/com/faire/gradle/release/ShowServiceChangePluginTest.kt
+++ b/build-targets-gradle-plugin/src/test/kotlin/com/faire/gradle/release/ShowServiceChangePluginTest.kt
@@ -15,16 +15,16 @@ import java.io.File
 import java.util.concurrent.TimeUnit
 
 @GradleTestKitConfiguration(
-    projectsRoot = "src/test/projects/release",
-    buildDirectoryMode = PRISTINE,
+  projectsRoot = "src/test/projects/release",
+  buildDirectoryMode = PRISTINE,
 )
 internal class ShowServiceChangePluginTest {
   @Test
   @GradleProject("basic-service-hierarchy")
   fun `execute with no changes does not find changes`(
-      @GradleProject.Runner runner: GradleRunner,
-      @GradleProject.Root root: File,
-      @TempDir outputDirectory: File,
+    @GradleProject.Runner runner: GradleRunner,
+    @GradleProject.Root root: File,
+    @TempDir outputDirectory: File,
   ) {
     gitInit(root)
 
@@ -32,13 +32,13 @@ internal class ShowServiceChangePluginTest {
     gitEmptyCommit(root)
 
     val result = runner
-        .withArguments(
-            SHOW_BUILD_TARGETS_TASK,
-            "--outputDirectory",
-            outputDirectory.toString(),
-            "--stacktrace",
-        )
-        .build()
+      .withArguments(
+        SHOW_BUILD_TARGETS_TASK,
+        "--outputDirectory",
+        outputDirectory.toString(),
+        "--stacktrace",
+      )
+      .build()
 
     assertThat(result).task(":service-project:$COMPUTE_RUNTIME_CLASSPATH_DEPENDENT_PROJECTS_TASK").isSuccess()
     assertThat(result).task(":service-project:$SHOW_BUILD_TARGETS_TASK").isSuccess()
@@ -59,20 +59,20 @@ internal class ShowServiceChangePluginTest {
   @Test
   @GradleProject("basic-service-hierarchy")
   fun `execute with changes to service project finds changes`(
-      @GradleProject.Runner runner: GradleRunner,
-      @GradleProject.Root root: File,
-      @TempDir outputDirectory: File,
+    @GradleProject.Runner runner: GradleRunner,
+    @GradleProject.Root root: File,
+    @TempDir outputDirectory: File,
   ) {
     gitInit(root)
 
     val result = runner
-        .withArguments(
-            SHOW_BUILD_TARGETS_TASK,
-            "--stacktrace",
-            "--outputDirectory",
-            outputDirectory.toString(),
-        )
-        .build()
+      .withArguments(
+        SHOW_BUILD_TARGETS_TASK,
+        "--stacktrace",
+        "--outputDirectory",
+        outputDirectory.toString(),
+      )
+      .build()
 
     assertThat(result).task(":$COMPUTE_SOURCE_FOLDERS_TASK").isSuccess()
     assertThat(result).task(":service-project:$COMPUTE_RUNTIME_CLASSPATH_DEPENDENT_PROJECTS_TASK").isSuccess()
@@ -97,19 +97,19 @@ internal class ShowServiceChangePluginTest {
   @Test
   @GradleProject("basic-service-hierarchy")
   fun `execute with changes to dependency-project finds changes`(
-      @GradleProject.Runner runner: GradleRunner,
-      @GradleProject.Root root: File,
-      @TempDir outputDirectory: File,
+    @GradleProject.Runner runner: GradleRunner,
+    @GradleProject.Root root: File,
+    @TempDir outputDirectory: File,
   ) {
     gitInit(root)
 
     val result = runner
-        .withArguments(
-            SHOW_BUILD_TARGETS_TASK,
-            "--outputDirectory",
-            outputDirectory.toString(),
-        )
-        .build()
+      .withArguments(
+        SHOW_BUILD_TARGETS_TASK,
+        "--outputDirectory",
+        outputDirectory.toString(),
+      )
+      .build()
 
     assertThat(result).task(":$COMPUTE_SOURCE_FOLDERS_TASK").isSuccess()
     assertThat(result).task(":service-project:$COMPUTE_RUNTIME_CLASSPATH_DEPENDENT_PROJECTS_TASK").isSuccess()
@@ -134,19 +134,19 @@ internal class ShowServiceChangePluginTest {
   @Test
   @GradleProject("basic-service-hierarchy")
   fun `changing project build files re-runs computeSourceFolders`(
-      @GradleProject.Runner runner: GradleRunner,
-      @GradleProject.Root root: File,
-      @TempDir outputDirectory: File,
+    @GradleProject.Runner runner: GradleRunner,
+    @GradleProject.Root root: File,
+    @TempDir outputDirectory: File,
   ) {
     gitInit(root)
 
     val result = runner
-        .withArguments(
-            SHOW_BUILD_TARGETS_TASK,
-            "--outputDirectory",
-            outputDirectory.toString(),
-        )
-        .build()
+      .withArguments(
+        SHOW_BUILD_TARGETS_TASK,
+        "--outputDirectory",
+        outputDirectory.toString(),
+      )
+      .build()
 
     assertThat(result).task(":$COMPUTE_SOURCE_FOLDERS_TASK").isSuccess()
     assertThat(result).task(":service-project:$COMPUTE_RUNTIME_CLASSPATH_DEPENDENT_PROJECTS_TASK").isSuccess()
@@ -171,20 +171,20 @@ internal class ShowServiceChangePluginTest {
   @Test
   @GradleProject("basic-service-hierarchy")
   fun `if output directory is relative, uses root projectDir as relative root`(
-      @GradleProject.Runner runner: GradleRunner,
-      @GradleProject.Root root: File,
+    @GradleProject.Runner runner: GradleRunner,
+    @GradleProject.Root root: File,
   ) {
     gitInit(root)
 
     val outputDirectory = File("build/release")
 
     val result = runner
-        .withArguments(
-            SHOW_BUILD_TARGETS_TASK,
-            "--outputDirectory",
-            outputDirectory.path,
-        )
-        .build()
+      .withArguments(
+        SHOW_BUILD_TARGETS_TASK,
+        "--outputDirectory",
+        outputDirectory.path,
+      )
+      .build()
 
     assertThat(result).task(":$COMPUTE_SOURCE_FOLDERS_TASK").isSuccess()
     assertThat(result).task(":service-project:$COMPUTE_RUNTIME_CLASSPATH_DEPENDENT_PROJECTS_TASK").isSuccess()
@@ -198,20 +198,19 @@ internal class ShowServiceChangePluginTest {
   @Test
   @GradleProject("basic-service-hierarchy")
   fun `emptying a folder does not throw`(
-      @GradleProject.Runner runner: GradleRunner,
-      @GradleProject.Root root: File,
-      @TempDir outputDirectory: File,
+    @GradleProject.Runner runner: GradleRunner,
+    @GradleProject.Root root: File,
+    @TempDir outputDirectory: File,
   ) {
     gitInit(root)
 
     runner
-        .withArguments(
-          SHOW_BUILD_TARGETS_TASK,
-            "--outputDirectory",
-            outputDirectory.toString(),
-        )
-        .withDebug(true)
-        .build()
+      .withArguments(
+        SHOW_BUILD_TARGETS_TASK,
+        "--outputDirectory",
+        outputDirectory.toString(),
+      )
+      .build()
 
     val initialResourcesHash = getCommitHash(root)
 
@@ -222,19 +221,66 @@ internal class ShowServiceChangePluginTest {
 
     // verify does not throw
     runner
-        .withArguments(
-          SHOW_BUILD_TARGETS_TASK,
-            "--outputDirectory",
-            outputDirectory.toString(),
-            "--currentCommitRef=$deletedResourcesHash",
-            "--previousCommitRef=$initialResourcesHash",
-        )
-        .build()
+      .withArguments(
+        SHOW_BUILD_TARGETS_TASK,
+        "--outputDirectory",
+        outputDirectory.toString(),
+        "--currentCommitRef=$deletedResourcesHash",
+        "--previousCommitRef=$initialResourcesHash",
+      )
+      .build()
+  }
+
+  @Test
+  @GradleProject("basic-service-hierarchy")
+  fun `changing an excluded project file does not affect project files`(
+    @GradleProject.Runner runner: GradleRunner,
+    @GradleProject.Root root: File,
+    @TempDir outputDirectory: File,
+  ) {
+    gitInit(root)
+
+    // Ignore the `src/resources` folder
+    with(root.resolve("build.gradle.kts")) {
+      appendText(
+        """
+          
+          showBuildTargets {
+            sourceExcludePatterns.add(".+/src/[\\w+\\-_]+/resources/?.*")
+          }
+        """.trimIndent()
+      )
+    }
+
+    val initialResourcesHash = getCommitHash(root)
+
+    updateAndCommitNewResourcesToProject(root, "dependency-project")
+    updateAndCommitNewResourcesToProject(root, "dependency-project-2")
+
+    val addedResourcesHash = getCommitHash(root)
+
+    val result = runner
+      .withArguments(
+        SHOW_BUILD_TARGETS_TASK,
+        "--outputDirectory",
+        outputDirectory.toString(),
+        "--currentCommitRef=$addedResourcesHash",
+        "--previousCommitRef=$initialResourcesHash",
+      )
+      .build()
+
+    assertThat(result).task(":$COMPUTE_SOURCE_FOLDERS_TASK").isSuccess()
+    assertThat(result).task(":service-project:$COMPUTE_RUNTIME_CLASSPATH_DEPENDENT_PROJECTS_TASK").isSuccess()
+    assertThat(result).task(":service-project:$SHOW_BUILD_TARGETS_TASK").isSuccess()
+    assertThat(result).task(":service-project-2:$COMPUTE_RUNTIME_CLASSPATH_DEPENDENT_PROJECTS_TASK").isSuccess()
+    assertThat(result).task(":service-project-2:$SHOW_BUILD_TARGETS_TASK").isSuccess()
+
+    assertProjectStatuses(root.resolve(outputDirectory), project1 = false, project2 = false)
   }
 
   private fun assertProjectStatuses(outputDirectory: File, project1: Boolean, project2: Boolean) {
     assertThat(outputDirectory)
-        .isDirectoryContaining("glob:**.status")
+      .isDirectoryContaining("glob:**.status")
     assertThat(outputDirectory.resolve("service-project.status")).hasContent(project1.toString())
     assertThat(outputDirectory.resolve("service-project-2.status")).hasContent(project2.toString())
   }
@@ -284,19 +330,19 @@ internal class ShowServiceChangePluginTest {
 
   private fun git(root: File, vararg command: String): String {
     val process = ProcessBuilder()
-        .directory(root)
-        .command("git", *command)
-        .start()
+      .directory(root)
+      .command("git", *command)
+      .start()
 
     assertThat(process.waitFor(5, TimeUnit.SECONDS))
-        .`as` { "Failed to execute: `git ${command.joinToString(" ")}` in $root" }
-        .isTrue()
+      .`as` { "Failed to execute: `git ${command.joinToString(" ")}` in $root" }
+      .isTrue()
 
     val output = process.inputReader().use { it.readText().trim() }
 
     assertThat(process.exitValue())
-        .`as` { "Failed to execute: `git ${command.joinToString(" ")}` in $root:\n$output" }
-        .isZero()
+      .`as` { "Failed to execute: `git ${command.joinToString(" ")}` in $root:\n$output" }
+      .isZero()
 
     return output
   }

--- a/build-targets-gradle-plugin/src/test/kotlin/com/faire/gradle/release/ShowServiceChangePluginTest.kt
+++ b/build-targets-gradle-plugin/src/test/kotlin/com/faire/gradle/release/ShowServiceChangePluginTest.kt
@@ -15,16 +15,16 @@ import java.io.File
 import java.util.concurrent.TimeUnit
 
 @GradleTestKitConfiguration(
-  projectsRoot = "src/test/projects/release",
-  buildDirectoryMode = PRISTINE,
+    projectsRoot = "src/test/projects/release",
+    buildDirectoryMode = PRISTINE,
 )
 internal class ShowServiceChangePluginTest {
   @Test
   @GradleProject("basic-service-hierarchy")
   fun `execute with no changes does not find changes`(
-    @GradleProject.Runner runner: GradleRunner,
-    @GradleProject.Root root: File,
-    @TempDir outputDirectory: File,
+      @GradleProject.Runner runner: GradleRunner,
+      @GradleProject.Root root: File,
+      @TempDir outputDirectory: File,
   ) {
     gitInit(root)
 
@@ -32,13 +32,13 @@ internal class ShowServiceChangePluginTest {
     gitEmptyCommit(root)
 
     val result = runner
-      .withArguments(
-        SHOW_BUILD_TARGETS_TASK,
-        "--outputDirectory",
-        outputDirectory.toString(),
-        "--stacktrace",
-      )
-      .build()
+        .withArguments(
+            SHOW_BUILD_TARGETS_TASK,
+            "--outputDirectory",
+            outputDirectory.toString(),
+            "--stacktrace",
+        )
+        .build()
 
     assertThat(result).task(":service-project:$COMPUTE_RUNTIME_CLASSPATH_DEPENDENT_PROJECTS_TASK").isSuccess()
     assertThat(result).task(":service-project:$SHOW_BUILD_TARGETS_TASK").isSuccess()
@@ -59,20 +59,20 @@ internal class ShowServiceChangePluginTest {
   @Test
   @GradleProject("basic-service-hierarchy")
   fun `execute with changes to service project finds changes`(
-    @GradleProject.Runner runner: GradleRunner,
-    @GradleProject.Root root: File,
-    @TempDir outputDirectory: File,
+      @GradleProject.Runner runner: GradleRunner,
+      @GradleProject.Root root: File,
+      @TempDir outputDirectory: File,
   ) {
     gitInit(root)
 
     val result = runner
-      .withArguments(
-        SHOW_BUILD_TARGETS_TASK,
-        "--stacktrace",
-        "--outputDirectory",
-        outputDirectory.toString(),
-      )
-      .build()
+        .withArguments(
+            SHOW_BUILD_TARGETS_TASK,
+            "--stacktrace",
+            "--outputDirectory",
+            outputDirectory.toString(),
+        )
+        .build()
 
     assertThat(result).task(":$COMPUTE_SOURCE_FOLDERS_TASK").isSuccess()
     assertThat(result).task(":service-project:$COMPUTE_RUNTIME_CLASSPATH_DEPENDENT_PROJECTS_TASK").isSuccess()
@@ -97,19 +97,19 @@ internal class ShowServiceChangePluginTest {
   @Test
   @GradleProject("basic-service-hierarchy")
   fun `execute with changes to dependency-project finds changes`(
-    @GradleProject.Runner runner: GradleRunner,
-    @GradleProject.Root root: File,
-    @TempDir outputDirectory: File,
+      @GradleProject.Runner runner: GradleRunner,
+      @GradleProject.Root root: File,
+      @TempDir outputDirectory: File,
   ) {
     gitInit(root)
 
     val result = runner
-      .withArguments(
-        SHOW_BUILD_TARGETS_TASK,
-        "--outputDirectory",
-        outputDirectory.toString(),
-      )
-      .build()
+        .withArguments(
+            SHOW_BUILD_TARGETS_TASK,
+            "--outputDirectory",
+            outputDirectory.toString(),
+        )
+        .build()
 
     assertThat(result).task(":$COMPUTE_SOURCE_FOLDERS_TASK").isSuccess()
     assertThat(result).task(":service-project:$COMPUTE_RUNTIME_CLASSPATH_DEPENDENT_PROJECTS_TASK").isSuccess()
@@ -134,19 +134,19 @@ internal class ShowServiceChangePluginTest {
   @Test
   @GradleProject("basic-service-hierarchy")
   fun `changing project build files re-runs computeSourceFolders`(
-    @GradleProject.Runner runner: GradleRunner,
-    @GradleProject.Root root: File,
-    @TempDir outputDirectory: File,
+      @GradleProject.Runner runner: GradleRunner,
+      @GradleProject.Root root: File,
+      @TempDir outputDirectory: File,
   ) {
     gitInit(root)
 
     val result = runner
-      .withArguments(
-        SHOW_BUILD_TARGETS_TASK,
-        "--outputDirectory",
-        outputDirectory.toString(),
-      )
-      .build()
+        .withArguments(
+            SHOW_BUILD_TARGETS_TASK,
+            "--outputDirectory",
+            outputDirectory.toString(),
+        )
+        .build()
 
     assertThat(result).task(":$COMPUTE_SOURCE_FOLDERS_TASK").isSuccess()
     assertThat(result).task(":service-project:$COMPUTE_RUNTIME_CLASSPATH_DEPENDENT_PROJECTS_TASK").isSuccess()
@@ -171,20 +171,20 @@ internal class ShowServiceChangePluginTest {
   @Test
   @GradleProject("basic-service-hierarchy")
   fun `if output directory is relative, uses root projectDir as relative root`(
-    @GradleProject.Runner runner: GradleRunner,
-    @GradleProject.Root root: File,
+      @GradleProject.Runner runner: GradleRunner,
+      @GradleProject.Root root: File,
   ) {
     gitInit(root)
 
     val outputDirectory = File("build/release")
 
     val result = runner
-      .withArguments(
-        SHOW_BUILD_TARGETS_TASK,
-        "--outputDirectory",
-        outputDirectory.path,
-      )
-      .build()
+        .withArguments(
+            SHOW_BUILD_TARGETS_TASK,
+            "--outputDirectory",
+            outputDirectory.path,
+        )
+        .build()
 
     assertThat(result).task(":$COMPUTE_SOURCE_FOLDERS_TASK").isSuccess()
     assertThat(result).task(":service-project:$COMPUTE_RUNTIME_CLASSPATH_DEPENDENT_PROJECTS_TASK").isSuccess()
@@ -198,19 +198,19 @@ internal class ShowServiceChangePluginTest {
   @Test
   @GradleProject("basic-service-hierarchy")
   fun `emptying a folder does not throw`(
-    @GradleProject.Runner runner: GradleRunner,
-    @GradleProject.Root root: File,
-    @TempDir outputDirectory: File,
+      @GradleProject.Runner runner: GradleRunner,
+      @GradleProject.Root root: File,
+      @TempDir outputDirectory: File,
   ) {
     gitInit(root)
 
     runner
-      .withArguments(
-        SHOW_BUILD_TARGETS_TASK,
-        "--outputDirectory",
-        outputDirectory.toString(),
-      )
-      .build()
+        .withArguments(
+            SHOW_BUILD_TARGETS_TASK,
+            "--outputDirectory",
+            outputDirectory.toString(),
+        )
+        .build()
 
     val initialResourcesHash = getCommitHash(root)
 
@@ -221,29 +221,29 @@ internal class ShowServiceChangePluginTest {
 
     // verify does not throw
     runner
-      .withArguments(
-        SHOW_BUILD_TARGETS_TASK,
-        "--outputDirectory",
-        outputDirectory.toString(),
-        "--currentCommitRef=$deletedResourcesHash",
-        "--previousCommitRef=$initialResourcesHash",
-      )
-      .build()
+        .withArguments(
+            SHOW_BUILD_TARGETS_TASK,
+            "--outputDirectory",
+            outputDirectory.toString(),
+            "--currentCommitRef=$deletedResourcesHash",
+            "--previousCommitRef=$initialResourcesHash",
+        )
+        .build()
   }
 
   @Test
   @GradleProject("basic-service-hierarchy")
   fun `changing an excluded project file does not affect project files`(
-    @GradleProject.Runner runner: GradleRunner,
-    @GradleProject.Root root: File,
-    @TempDir outputDirectory: File,
+      @GradleProject.Runner runner: GradleRunner,
+      @GradleProject.Root root: File,
+      @TempDir outputDirectory: File,
   ) {
     gitInit(root)
 
     // Ignore the `src/resources` folder
     with(root.resolve("build.gradle.kts")) {
       appendText(
-        """
+          """
           
           showBuildTargets {
             sourceExcludePatterns.add(".+/src/[\\w+\\-_]+/resources/?.*")
@@ -260,14 +260,14 @@ internal class ShowServiceChangePluginTest {
     val addedResourcesHash = getCommitHash(root)
 
     val result = runner
-      .withArguments(
-        SHOW_BUILD_TARGETS_TASK,
-        "--outputDirectory",
-        outputDirectory.toString(),
-        "--currentCommitRef=$addedResourcesHash",
-        "--previousCommitRef=$initialResourcesHash",
-      )
-      .build()
+        .withArguments(
+            SHOW_BUILD_TARGETS_TASK,
+            "--outputDirectory",
+            outputDirectory.toString(),
+            "--currentCommitRef=$addedResourcesHash",
+            "--previousCommitRef=$initialResourcesHash",
+        )
+        .build()
 
     assertThat(result).task(":$COMPUTE_SOURCE_FOLDERS_TASK").isSuccess()
     assertThat(result).task(":service-project:$COMPUTE_RUNTIME_CLASSPATH_DEPENDENT_PROJECTS_TASK").isSuccess()
@@ -280,7 +280,7 @@ internal class ShowServiceChangePluginTest {
 
   private fun assertProjectStatuses(outputDirectory: File, project1: Boolean, project2: Boolean) {
     assertThat(outputDirectory)
-      .isDirectoryContaining("glob:**.status")
+        .isDirectoryContaining("glob:**.status")
     assertThat(outputDirectory.resolve("service-project.status")).hasContent(project1.toString())
     assertThat(outputDirectory.resolve("service-project-2.status")).hasContent(project2.toString())
   }
@@ -330,19 +330,19 @@ internal class ShowServiceChangePluginTest {
 
   private fun git(root: File, vararg command: String): String {
     val process = ProcessBuilder()
-      .directory(root)
-      .command("git", *command)
-      .start()
+        .directory(root)
+        .command("git", *command)
+        .start()
 
     assertThat(process.waitFor(5, TimeUnit.SECONDS))
-      .`as` { "Failed to execute: `git ${command.joinToString(" ")}` in $root" }
-      .isTrue()
+        .`as` { "Failed to execute: `git ${command.joinToString(" ")}` in $root" }
+        .isTrue()
 
     val output = process.inputReader().use { it.readText().trim() }
 
     assertThat(process.exitValue())
-      .`as` { "Failed to execute: `git ${command.joinToString(" ")}` in $root:\n$output" }
-      .isZero()
+        .`as` { "Failed to execute: `git ${command.joinToString(" ")}` in $root:\n$output" }
+        .isZero()
 
     return output
   }

--- a/build-targets-gradle-plugin/src/test/projects/release/basic-service-hierarchy/build.gradle.kts
+++ b/build-targets-gradle-plugin/src/test/projects/release/basic-service-hierarchy/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.faire.gradle.release.ShowBuildTargetsForChangeExtension
-
 plugins {
   alias(libs.plugins.kotlin) apply false
   id("com.faire.build-targets")

--- a/build-targets-gradle-plugin/src/test/projects/release/basic-service-hierarchy/build.gradle.kts
+++ b/build-targets-gradle-plugin/src/test/projects/release/basic-service-hierarchy/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.faire.gradle.release.ShowBuildTargetsForChangeExtension
+
 plugins {
   alias(libs.plugins.kotlin) apply false
   id("com.faire.build-targets")


### PR DESCRIPTION
Within our internal code-base, we would like to be able to filter out changes to specific source directories. For example, `src/test`. These exclusion patterns enable this filtering and avoiding triggering specific commits as updating targets.