### PR TITLE
Updating build-targets plugin to skip empty projects

### DIFF
--- a/build-targets-gradle-plugin/build.gradle.kts
+++ b/build-targets-gradle-plugin/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.faire"
-version = "0.0.1"
+version = "0.0.2"
 
 dependencies {
   api(kotlin("stdlib"))

--- a/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ComputeSourceFoldersTask.kt
+++ b/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ComputeSourceFoldersTask.kt
@@ -63,6 +63,24 @@ internal abstract class ComputeSourceFoldersTask @Inject constructor(
   val rootProjectDirectory: DirectoryProperty = objects.directoryProperty()
       .convention(project.rootProject.layout.projectDirectory)
 
+  // Done this way to avoid using this in the implementation, making it configuration-cache safe.
+  // If this is too slow in the future, we can consider making this task run _per project_ and do a map-reduce
+  // style to collect the results of this task per project within the `ShowServiceChangeStatusTask`. This would
+  // parallelize this, letting it run "faster" in the future.
+  @Input
+  val projectToSourceDirectories: MapProperty<String, Set<File>> = objects.mapProperty<String, Set<File>>()
+      .value(
+          project.provider {
+            project.rootProject.subprojects
+                .filter { it.plugins.hasPlugin(JavaPlugin::class.java) }
+                .parallelStream()
+                .collect(Collectors.toMap({ it.path }, ::computeWatchedFiles))
+          },
+      )
+      .apply {
+        finalizeValueOnRead()
+      }
+
   @TaskAction
   fun execute() {
     val outputFile = jsonFile.asFile.get().apply {
@@ -72,13 +90,8 @@ internal abstract class ComputeSourceFoldersTask @Inject constructor(
     val gson = GsonUtils.gson
     val rootDirectory = rootProjectDirectory.asFile.get()
 
-    val projectToSourceDirectories =  project.rootProject.subprojects
-        .filter { it.plugins.hasPlugin(JavaPlugin::class.java) }
-        .parallelStream()
-        .collect(Collectors.toMap({ it.path }, ::computeWatchedFiles))
-
     val json = gson.toJson(
-        projectToSourceDirectories.mapValues { (_, files) ->
+        projectToSourceDirectories.get().mapValues { (_, files) ->
           files.map { it.relativeTo(rootDirectory).path }
         },
     )

--- a/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ComputeSourceFoldersTask.kt
+++ b/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ComputeSourceFoldersTask.kt
@@ -6,6 +6,7 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.SetProperty
@@ -62,22 +63,6 @@ internal abstract class ComputeSourceFoldersTask @Inject constructor(
   val rootProjectDirectory: DirectoryProperty = objects.directoryProperty()
       .convention(project.rootProject.layout.projectDirectory)
 
-  // Done this way to avoid using this in the implementation, making it configuration-cache safe.
-  // If this is too slow in the future, we can consider making this task run _per project_ and do a map-reduce
-  // style to collect the results of this task per project within the `ShowServiceChangeStatusTask`. This would
-  // parallelize this, letting it run "faster" in the future.
-  @Input
-  val projectToSourceDirectories: MapProperty<String, Set<File>> = objects.mapProperty<String, Set<File>>()
-      .value(
-          project.provider {
-            project.rootProject.subprojects.parallelStream()
-                .collect(Collectors.toMap({ it.path }, ::computeWatchedFiles))
-          },
-      )
-      .apply {
-        finalizeValueOnRead()
-      }
-
   @TaskAction
   fun execute() {
     val outputFile = jsonFile.asFile.get().apply {
@@ -87,8 +72,13 @@ internal abstract class ComputeSourceFoldersTask @Inject constructor(
     val gson = GsonUtils.gson
     val rootDirectory = rootProjectDirectory.asFile.get()
 
+    val projectToSourceDirectories =  project.rootProject.subprojects
+        .filter { it.plugins.hasPlugin(JavaPlugin::class.java) }
+        .parallelStream()
+        .collect(Collectors.toMap({ it.path }, ::computeWatchedFiles))
+
     val json = gson.toJson(
-        projectToSourceDirectories.get().mapValues { (_, files) ->
+        projectToSourceDirectories.mapValues { (_, files) ->
           files.map { it.relativeTo(rootDirectory).path }
         },
     )

--- a/build-targets-gradle-plugin/src/test/kotlin/com/faire/gradle/release/ShowServiceChangePluginTest.kt
+++ b/build-targets-gradle-plugin/src/test/kotlin/com/faire/gradle/release/ShowServiceChangePluginTest.kt
@@ -37,7 +37,6 @@ internal class ShowServiceChangePluginTest {
         .withArguments(
             SHOW_BUILD_TARGETS_TASK,
             "--outputDirectory",
-            "--configuration-cache",
             outputDirectory.toString(),
             "--stacktrace",
         )
@@ -75,7 +74,6 @@ internal class ShowServiceChangePluginTest {
             SHOW_BUILD_TARGETS_TASK,
             "--stacktrace",
             "--outputDirectory",
-            "--configuration-cache",
             outputDirectory.toString(),
         )
         .build()
@@ -114,7 +112,6 @@ internal class ShowServiceChangePluginTest {
         .withArguments(
             SHOW_BUILD_TARGETS_TASK,
             "--outputDirectory",
-            "--configuration-cache",
             outputDirectory.toString(),
         )
         .build()
@@ -153,7 +150,6 @@ internal class ShowServiceChangePluginTest {
         .withArguments(
             SHOW_BUILD_TARGETS_TASK,
             "--outputDirectory",
-            "--configuration-cache",
             outputDirectory.toString(),
         )
         .build()
@@ -193,7 +189,6 @@ internal class ShowServiceChangePluginTest {
         .withArguments(
             SHOW_BUILD_TARGETS_TASK,
             "--outputDirectory",
-            "--configuration-cache",
             outputDirectory.path,
         )
         .build()
@@ -221,7 +216,6 @@ internal class ShowServiceChangePluginTest {
         .withArguments(
             SHOW_BUILD_TARGETS_TASK,
             "--outputDirectory",
-            "--configuration-cache",
             outputDirectory.toString(),
         )
         .build()
@@ -239,7 +233,6 @@ internal class ShowServiceChangePluginTest {
         .withArguments(
             SHOW_BUILD_TARGETS_TASK,
             "--outputDirectory",
-            "--configuration-cache",
             outputDirectory.toString(),
             "--currentCommitRef=$deletedResourcesHash",
             "--previousCommitRef=$initialResourcesHash",
@@ -281,7 +274,6 @@ internal class ShowServiceChangePluginTest {
         .withArguments(
             SHOW_BUILD_TARGETS_TASK,
             "--outputDirectory",
-            "--configuration-cache",
             outputDirectory.toString(),
             "--currentCommitRef=$addedResourcesHash",
             "--previousCommitRef=$initialResourcesHash",

--- a/build-targets-gradle-plugin/src/test/kotlin/com/faire/gradle/release/ShowServiceChangePluginTest.kt
+++ b/build-targets-gradle-plugin/src/test/kotlin/com/faire/gradle/release/ShowServiceChangePluginTest.kt
@@ -7,7 +7,9 @@ import net.navatwo.gradle.testkit.assertj.task
 import net.navatwo.gradle.testkit.junit5.GradleProject
 import net.navatwo.gradle.testkit.junit5.GradleTestKitConfiguration
 import net.navatwo.gradle.testkit.junit5.GradleTestKitConfiguration.BuildDirectoryMode.PRISTINE
+import org.assertj.core.api.Assertions
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -35,6 +37,7 @@ internal class ShowServiceChangePluginTest {
         .withArguments(
             SHOW_BUILD_TARGETS_TASK,
             "--outputDirectory",
+            "--configuration-cache",
             outputDirectory.toString(),
             "--stacktrace",
         )
@@ -46,6 +49,7 @@ internal class ShowServiceChangePluginTest {
     assertThat(result).task(":service-project-2:$SHOW_BUILD_TARGETS_TASK").isSuccess()
 
     assertProjectStatuses(outputDirectory, project1 = false, project2 = false)
+    assertConfigurationCacheStored(result)
 
     val secondResult = runner.build()
     assertThat(secondResult).task(":service-project:$COMPUTE_RUNTIME_CLASSPATH_DEPENDENT_PROJECTS_TASK").isUpToDate()
@@ -54,6 +58,7 @@ internal class ShowServiceChangePluginTest {
     assertThat(secondResult).task(":service-project-2:$SHOW_BUILD_TARGETS_TASK").isUpToDate()
 
     assertProjectStatuses(outputDirectory, project1 = false, project2 = false)
+
   }
 
   @Test
@@ -70,9 +75,11 @@ internal class ShowServiceChangePluginTest {
             SHOW_BUILD_TARGETS_TASK,
             "--stacktrace",
             "--outputDirectory",
+            "--configuration-cache",
             outputDirectory.toString(),
         )
         .build()
+    assertConfigurationCacheStored(result)
 
     assertThat(result).task(":$COMPUTE_SOURCE_FOLDERS_TASK").isSuccess()
     assertThat(result).task(":service-project:$COMPUTE_RUNTIME_CLASSPATH_DEPENDENT_PROJECTS_TASK").isSuccess()
@@ -107,9 +114,11 @@ internal class ShowServiceChangePluginTest {
         .withArguments(
             SHOW_BUILD_TARGETS_TASK,
             "--outputDirectory",
+            "--configuration-cache",
             outputDirectory.toString(),
         )
         .build()
+    assertConfigurationCacheStored(result)
 
     assertThat(result).task(":$COMPUTE_SOURCE_FOLDERS_TASK").isSuccess()
     assertThat(result).task(":service-project:$COMPUTE_RUNTIME_CLASSPATH_DEPENDENT_PROJECTS_TASK").isSuccess()
@@ -144,9 +153,11 @@ internal class ShowServiceChangePluginTest {
         .withArguments(
             SHOW_BUILD_TARGETS_TASK,
             "--outputDirectory",
+            "--configuration-cache",
             outputDirectory.toString(),
         )
         .build()
+    assertConfigurationCacheStored(result)
 
     assertThat(result).task(":$COMPUTE_SOURCE_FOLDERS_TASK").isSuccess()
     assertThat(result).task(":service-project:$COMPUTE_RUNTIME_CLASSPATH_DEPENDENT_PROJECTS_TASK").isSuccess()
@@ -182,9 +193,11 @@ internal class ShowServiceChangePluginTest {
         .withArguments(
             SHOW_BUILD_TARGETS_TASK,
             "--outputDirectory",
+            "--configuration-cache",
             outputDirectory.path,
         )
         .build()
+    assertConfigurationCacheStored(result)
 
     assertThat(result).task(":$COMPUTE_SOURCE_FOLDERS_TASK").isSuccess()
     assertThat(result).task(":service-project:$COMPUTE_RUNTIME_CLASSPATH_DEPENDENT_PROJECTS_TASK").isSuccess()
@@ -204,13 +217,15 @@ internal class ShowServiceChangePluginTest {
   ) {
     gitInit(root)
 
-    runner
+    val result = runner
         .withArguments(
             SHOW_BUILD_TARGETS_TASK,
             "--outputDirectory",
+            "--configuration-cache",
             outputDirectory.toString(),
         )
         .build()
+    assertConfigurationCacheStored(result)
 
     val initialResourcesHash = getCommitHash(root)
 
@@ -224,6 +239,7 @@ internal class ShowServiceChangePluginTest {
         .withArguments(
             SHOW_BUILD_TARGETS_TASK,
             "--outputDirectory",
+            "--configuration-cache",
             outputDirectory.toString(),
             "--currentCommitRef=$deletedResourcesHash",
             "--previousCommitRef=$initialResourcesHash",
@@ -265,11 +281,13 @@ internal class ShowServiceChangePluginTest {
         .withArguments(
             SHOW_BUILD_TARGETS_TASK,
             "--outputDirectory",
+            "--configuration-cache",
             outputDirectory.toString(),
             "--currentCommitRef=$addedResourcesHash",
             "--previousCommitRef=$initialResourcesHash",
         )
         .build()
+    assertConfigurationCacheStored(result)
 
     assertThat(result).task(":$COMPUTE_SOURCE_FOLDERS_TASK").isSuccess()
     assertThat(result).task(":service-project:$COMPUTE_RUNTIME_CLASSPATH_DEPENDENT_PROJECTS_TASK").isSuccess()
@@ -285,6 +303,10 @@ internal class ShowServiceChangePluginTest {
         .isDirectoryContaining("glob:**.status")
     assertThat(outputDirectory.resolve("service-project.status")).hasContent(project1.toString())
     assertThat(outputDirectory.resolve("service-project-2.status")).hasContent(project2.toString())
+  }
+
+  private fun assertConfigurationCacheStored(result: BuildResult) {
+    assertThat(result.output).contains("Configuration cache entry stored.")
   }
 
   private fun gitInit(root: File) {

--- a/build-targets-gradle-plugin/src/test/kotlin/com/faire/gradle/release/ShowServiceChangePluginTest.kt
+++ b/build-targets-gradle-plugin/src/test/kotlin/com/faire/gradle/release/ShowServiceChangePluginTest.kt
@@ -7,7 +7,6 @@ import net.navatwo.gradle.testkit.assertj.task
 import net.navatwo.gradle.testkit.junit5.GradleProject
 import net.navatwo.gradle.testkit.junit5.GradleTestKitConfiguration
 import net.navatwo.gradle.testkit.junit5.GradleTestKitConfiguration.BuildDirectoryMode.PRISTINE
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
@@ -57,7 +56,6 @@ internal class ShowServiceChangePluginTest {
     assertThat(secondResult).task(":service-project-2:$SHOW_BUILD_TARGETS_TASK").isUpToDate()
 
     assertProjectStatuses(outputDirectory, project1 = false, project2 = false)
-
   }
 
   @Test

--- a/build-targets-gradle-plugin/src/test/projects/release/basic-service-hierarchy/emptydir/lib-project/build.gradle.kts
+++ b/build-targets-gradle-plugin/src/test/projects/release/basic-service-hierarchy/emptydir/lib-project/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+  kotlin("jvm")
+}

--- a/build-targets-gradle-plugin/src/test/projects/release/basic-service-hierarchy/emptydir/lib-project/src/main/kotlin/com/faire/Lib.kt
+++ b/build-targets-gradle-plugin/src/test/projects/release/basic-service-hierarchy/emptydir/lib-project/src/main/kotlin/com/faire/Lib.kt
@@ -1,0 +1,3 @@
+package com.faire
+
+object Lib

--- a/build-targets-gradle-plugin/src/test/projects/release/basic-service-hierarchy/gradle.properties
+++ b/build-targets-gradle-plugin/src/test/projects/release/basic-service-hierarchy/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.configuration.cache=true
+org.gradle.configuration-cache.problems=fail

--- a/build-targets-gradle-plugin/src/test/projects/release/basic-service-hierarchy/gradle.properties
+++ b/build-targets-gradle-plugin/src/test/projects/release/basic-service-hierarchy/gradle.properties
@@ -1,2 +1,2 @@
-org.gradle.configuration.cache=true
+org.gradle.configuration-cache=true
 org.gradle.configuration-cache.problems=fail

--- a/build-targets-gradle-plugin/src/test/projects/release/basic-service-hierarchy/settings.gradle.kts
+++ b/build-targets-gradle-plugin/src/test/projects/release/basic-service-hierarchy/settings.gradle.kts
@@ -2,6 +2,8 @@ rootProject.name = "test-project"
 
 include(
   ":dependency-project",
+  // This emptydir parent directory structure ensures the plugin doesn't have trouble with empty projects.
+  ":emptydir:lib-project",
   ":service-project",
   ":service-project-2",
 )


### PR DESCRIPTION
This is necessary to skip empty projects that will no longer have the kotlin plugin applied to them (for no reason)

I think it also moves some logic from configuration phase to execution which should speed things up a tiny bit

It unblocks this for me too https://github.com/Faire/backend/pull/174592