### PR TITLE
feat: Update to use Gradle-recommended build graph traversal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: {{ matrix.gradle-version }}
+          gradle-version: ${{ matrix.gradle-version }}
 
       - name: Compile classes
         run: ./gradlew classes testClasses --continue

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: {{ matrix.gradle-version }}
+          gradle-version: '{{ matrix.gradle-version }}'
 
       - name: Compile classes
         run: ./gradlew classes testClasses --continue

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ permissions: read-all
 jobs:
   ci:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        gradle-version: ['current', '8.12.1', '7.6.4']
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -24,6 +27,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: {{ matrix.gradle-version }}
 
       - name: Compile classes
         run: ./gradlew classes testClasses --continue

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: '{{ matrix.gradle-version }}'
+          gradle-version: {{ matrix.gradle-version }}
 
       - name: Compile classes
         run: ./gradlew classes testClasses --continue

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -43,6 +43,7 @@
       </option>
       <option name="IMPORT_LAYOUT_TABLE">
         <value>
+          <package name="" withSubpackages="true" static="false" module="true" />
           <package name="" withSubpackages="true" static="false" />
           <emptyLine />
           <package name="" withSubpackages="true" static="true" />

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For all projects with `application` applied, each has a task `showServiceChangeS
 By running:
 
 ```shell
-./gradlew showServiceChangeStatus \
+./gradlew showBuildTargetsForChange \
     # Location where `${gradle_project_name}.status` files are created \
     --outputDirectory=build/application_statuses \
     # Commit ref to diff against, e.g. branch name, hash \

--- a/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ComputeDependentProjectsTask.kt
+++ b/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ComputeDependentProjectsTask.kt
@@ -65,4 +65,3 @@ internal abstract class ComputeDependentProjectsTask @Inject constructor(
     }
   }
 }
-

--- a/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ComputeDependentProjectsTask.kt
+++ b/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ComputeDependentProjectsTask.kt
@@ -1,19 +1,19 @@
 package com.faire.gradle.release
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.Project
-import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier
+import org.gradle.api.artifacts.result.ResolvedComponentResult
+import org.gradle.api.artifacts.result.ResolvedVariantResult
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
-import org.gradle.api.provider.SetProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
 import org.gradle.kotlin.dsl.property
-import org.gradle.kotlin.dsl.setProperty
-import org.gradle.kotlin.dsl.withType
-import org.gradle.work.DisableCachingByDefault
+import java.util.TreeSet
 import javax.inject.Inject
 
 /**
@@ -21,18 +21,15 @@ import javax.inject.Inject
  *
  * @see com.faire.gradle.release.ShowServiceChangePluginTest for usage examples.
  */
-@DisableCachingByDefault(because = "This task walks the project configurations requiring access to `project`.")
+@CacheableTask
 internal abstract class ComputeDependentProjectsTask @Inject constructor(
     objects: ObjectFactory,
 ) : DefaultTask() {
-  @Input
-  val projectDependencyPaths: SetProperty<String> = objects.setProperty<String>()
-      .value(project.provider { getAllDependenciesForProjects(setOf(project)).map { it.path } })
-      .apply { finalizeValueOnRead() }
+  @get:Input
+  val rootComponent: Property<ResolvedComponentResult> = objects.property()
 
-  @field:Option(option = "configuration", description = "Name of configuration")
-  @Input
-  val configurationName = objects.property<String>()
+  @get:Input
+  val rootVariant: Property<ResolvedVariantResult> = objects.property()
 
   @Option(option = "dependentProjectsOutputFile", description = "Directory to write the output file")
   @OutputFile
@@ -41,34 +38,31 @@ internal abstract class ComputeDependentProjectsTask @Inject constructor(
 
   @TaskAction
   fun execute() {
-    val projectDependencyPaths = projectDependencyPaths.get().sorted()
+    val dependentProjectPaths = TreeSet<String>()
+    DependencyGraph.traverseGraph(
+        rootComponent = rootComponent.get(),
+        rootVariant = rootVariant.get(),
+        nodeCallback = { node ->
+          val projectPath = getProjectPath(node)
+          if (projectPath != null) {
+            dependentProjectPaths.add(projectPath)
+          }
+        },
+    )
+
     dependentProjectsListFile.asFile.get().apply {
       parentFile.mkdirs()
-      writeText(projectDependencyPaths.joinToString("\n"))
+      writeText(dependentProjectPaths.joinToString("\n"))
     }
   }
 
-  /** Gets all the project dependencies for a project, including transitive ones. */
-  private fun getAllDependenciesForProjects(
-      startingProjects: Set<Project>,
-      visitedProjects: Set<Project> = setOf(),
-  ): Set<Project> {
-    if (startingProjects.isEmpty()) {
-      return setOf()
+  private fun getProjectPath(variant: ResolvedVariantResult): String? {
+    val owner = variant.owner
+    return if (owner is ProjectComponentIdentifier) {
+      owner.projectPath
+    } else {
+      null
     }
-
-    val runtimeProjectDependencies = startingProjects.asSequence()
-        .flatMap { project ->
-          val runtimeClasspath = project.configurations.named(configurationName.get()).get()
-          runtimeClasspath.allDependencies.withType<ProjectDependency>()
-              // RE: Deprecation: We don't have a better path at the moment and we've asked Gradle for support!
-              .map { @Suppress("DEPRECATION") it.dependencyProject }
-        }
-        .toSet()
-
-    return runtimeProjectDependencies + getAllDependenciesForProjects(
-        startingProjects = runtimeProjectDependencies - visitedProjects,
-        visitedProjects = visitedProjects + startingProjects,
-    )
   }
 }
+

--- a/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ComputeSourceFoldersTask.kt
+++ b/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ComputeSourceFoldersTask.kt
@@ -6,7 +6,7 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
-import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.SetProperty
@@ -72,7 +72,7 @@ internal abstract class ComputeSourceFoldersTask @Inject constructor(
       .value(
           project.provider {
             project.rootProject.subprojects
-                .filter { it.plugins.hasPlugin(JavaPlugin::class.java) }
+                .filter { it.plugins.hasPlugin(JavaBasePlugin::class.java) }
                 .parallelStream()
                 .collect(Collectors.toMap({ it.path }, ::computeWatchedFiles))
           },

--- a/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/DependencyGraph.kt
+++ b/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/DependencyGraph.kt
@@ -1,0 +1,48 @@
+package com.faire.gradle.release
+
+import org.gradle.api.artifacts.result.ResolvedComponentResult
+import org.gradle.api.artifacts.result.ResolvedDependencyResult
+import org.gradle.api.artifacts.result.ResolvedVariantResult
+import org.gradle.api.artifacts.result.UnresolvedDependencyResult
+
+/**
+ * Provides tools for walking the configuration graph.
+ *
+ * **Source:** https://docs.gradle.org/current/userguide/dependency_graph_resolution.html
+ */
+internal object DependencyGraph {
+  fun traverseGraph(
+      rootComponent: ResolvedComponentResult,
+      rootVariant: ResolvedVariantResult,
+      nodeCallback: (ResolvedVariantResult) -> Unit = { _ -> },
+      edgeCallback: (ResolvedVariantResult, ResolvedVariantResult) -> Unit = { _, _ -> },
+  ) {
+    val seen = mutableSetOf(rootVariant)
+    nodeCallback(rootVariant)
+
+    val queue = ArrayDeque(listOf(rootVariant to rootComponent))
+    while (queue.isNotEmpty()) {
+      val (variant, component) = queue.removeFirst()
+
+      // Traverse this variant's dependencies
+      component.getDependenciesForVariant(variant).forEach { dependency ->
+        val resolved = when (dependency) {
+          is ResolvedDependencyResult -> dependency
+          is UnresolvedDependencyResult -> throw dependency.failure
+          else -> error("Unknown dependency type: $dependency")
+        }
+
+        if (!resolved.isConstraint) {
+          val toVariant = resolved.resolvedVariant
+
+          if (seen.add(toVariant)) {
+            nodeCallback(toVariant)
+            queue.addLast(toVariant to resolved.selected)
+          }
+
+          edgeCallback(variant, toVariant)
+        }
+      }
+    }
+  }
+}

--- a/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ShowBuildTargetsForChangePlugin.kt
+++ b/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ShowBuildTargetsForChangePlugin.kt
@@ -19,7 +19,7 @@ class ShowBuildTargetsForChangePlugin : Plugin<Project> {
   override fun apply(project: Project) {
     val rootProject = project.rootProject
     val computeSourceFolders = if (project == rootProject) {
-      rootProject.tasks.register<ComputeSourceFoldersTask>(COMPUTE_SOURCE_FOLDERS_TASK)
+      rootProject.tasks.register<ComputeSourceFoldersTask>(COMPUTE_SOURCE_FOLDERS_TASK) {}
     } else {
       rootProject.tasks.named<ComputeSourceFoldersTask>(COMPUTE_SOURCE_FOLDERS_TASK)
     }
@@ -31,11 +31,16 @@ class ShowBuildTargetsForChangePlugin : Plugin<Project> {
         val computeRuntimeClasspathDependentProjects = project.tasks.register<ComputeDependentProjectsTask>(
             COMPUTE_RUNTIME_CLASSPATH_DEPENDENT_PROJECTS_TASK,
         ) {
-          configurationName = "runtimeClasspath"
-        }
+          val runtimeClasspath = project.configurations.named("runtimeClasspath")
 
-        // For CLI usage
-        project.tasks.register<ComputeDependentProjectsTask>("computeDependentProjects")
+          rootComponent = runtimeClasspath.flatMap {
+            it.incoming.resolutionResult.rootComponent
+          }
+
+          rootVariant = runtimeClasspath.flatMap {
+            it.incoming.resolutionResult.rootVariant
+          }
+        }
 
         project.tasks.register<ShowBuildTargetsForChangeStatusTask>(SHOW_BUILD_TARGETS_TASK) {
           sourceFilesJsonFile = computeSourceFolders.flatMap { it.jsonFile }


### PR DESCRIPTION
When upgrading to Gradle 8.13 in #73, we were forced to suppress a usage of `dependencyProject`. In this PR, we update the code to use Gradle's recommended approach: https://docs.gradle.org/current/userguide/dependency_graph_resolution.html