### PR TITLE
release: Prepare for 0.1.0

### DIFF
--- a/build-targets-gradle-plugin/build.gradle.kts
+++ b/build-targets-gradle-plugin/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.faire"
-version = "0.0.3"
+version = "0.1.0"
 
 dependencies {
   api(kotlin("stdlib"))


### PR DESCRIPTION
Bumping a minor release as technically we removed a feature in #76 to specify the configuration name via `cli` _and_ the cli-specific gradle task.