### PR TITLE
Downgrade Kotlin version from 2.2.20 to 2.0.10 for now

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -4,6 +4,6 @@
     <option name="jvmTarget" value="21" />
   </component>
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.1.20" />
+    <option name="version" value="2.2.20" />
   </component>
 </project>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ gradle-better-testing = "0.0.6"
 junit-jupiter = "5.11.4"
 junit-platform = "1.10.2"
 
-kotlin = "2.2.20"
+kotlin = "2.0.10"
 
 [libraries]
 


### PR DESCRIPTION
For compatibility with projects still using Kotlin 2.0.10, as other parts of the toolchain (e.g. Detekt) have not yet caught up with the latest Kotlin release