### PR TITLE
fix: avoid OS argv limit in ShowBuildTargetsForChangeStatusTask

### DIFF
--- a/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ShowBuildTargetsForChangeStatusTask.kt
+++ b/build-targets-gradle-plugin/src/main/kotlin/com/faire/gradle/release/ShowBuildTargetsForChangeStatusTask.kt
@@ -22,6 +22,7 @@ import org.gradle.kotlin.dsl.property
 import org.gradle.process.ExecOperations
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.nio.file.Path
 import javax.inject.Inject
 
 /**
@@ -111,28 +112,46 @@ internal abstract class ShowBuildTargetsForChangeStatusTask @Inject constructor(
       addAll(projectToSourceDirectories.getValue(currentProjectPath.get()))
     }
 
-    val diffsFound = ByteArrayOutputStream().use { stdout ->
-      // Executes git and shows a single line if and only if `pathsToDiff` files have changed
-      execOperations.exec {
-        commandLine(
-            "git",
-            "log",
-            "--oneline",
-            "${previousCommitRef.get()}..${currentCommitRef.get()}",
-            "--", // add paths separator
-        )
-
-        args(pathsToDiff)
-
-        standardOutput = stdout
-      }.assertNormalExitValue()
-
-      stdout.toString().isNotBlank()
-    }
+    // We previously invoked `git log -- <every path>` with `pathsToDiff` as argv, which blew past OS argv limits on
+    // large modules. Instead we list every changed file in the range once (no path arguments) and intersect in-process.
+    val diffsFound = anyChangedFileMatches(pathsToDiff)
 
     val outputFile = outputFile.get()
     outputFile.parentFile.mkdirs()
     outputFile.writeText("$diffsFound")
+  }
+
+  private fun anyChangedFileMatches(pathsToDiff: Set<File>): Boolean {
+    if (pathsToDiff.isEmpty()) {
+      return false
+    }
+
+    val targets: Set<Path> = pathsToDiff.mapTo(mutableSetOf()) { it.toPath().toAbsolutePath().normalize() }
+    val repoRoot = File(rootProjectPath.get()).toPath().toAbsolutePath().normalize()
+
+    return listChangedFiles().any { relativePath ->
+      val changed = repoRoot.resolve(relativePath).normalize()
+      targets.any { target -> changed.startsWith(target) }
+    }
+  }
+
+  private fun listChangedFiles(): Sequence<String> {
+    val stdout = ByteArrayOutputStream().use { out ->
+      execOperations.exec {
+        commandLine(
+            "git",
+            "diff",
+            "--name-only",
+            "-z",
+            "${previousCommitRef.get()}..${currentCommitRef.get()}",
+        )
+        standardOutput = out
+      }.assertNormalExitValue()
+      out.toByteArray()
+    }
+    return String(stdout, Charsets.UTF_8)
+        .splitToSequence('\u0000')
+        .filter { it.isNotEmpty() }
   }
 
   private fun readSourceFilesPerProjectPath(): Map<String, Set<File>> {


### PR DESCRIPTION
## Summary

`ShowBuildTargetsForChangeStatusTask` was passing every tracked source path to `git log -- <paths>` as argv. On large modules this exceeded the OS argv limit and the task failed with:

```
Execution failed for task ':backend:showBuildTargetsForChange'.
> Process 'command 'git'' could not be started because the command line exceed operating system limits.
```

This PR replaces the variadic invocation with a single `git diff --name-only -z <prev>..<curr>` call that takes no path arguments. The changed-file list (bounded by actual changes, not by source-tree size) is intersected with the configured paths in-process, so the argv limit is no longer reachable regardless of how many source files the module tracks.

## Why this change is needed

The previous design's command line grew linearly with the size of the source tree. For sufficiently large subprojects in the consuming monorepo this blew past `ARG_MAX` and broke the task outright. Switching to a path-argument-free git command sidesteps the limit entirely with one git invocation per task (same number as before).

Considered alternatives:
- `git log --pathspec-from-file=-` (pipe paths via stdin) — not supported by `git log` or `git diff`, only by mutating commands like `git add`/`commit`/`restore`.
- Batching `git log -- <chunk>` into multiple invocations — preserves semantics exactly but forks N times per project.

## Semantic note (worth calling out)

This is a small behavioral change: the old code asked **"did any commit in the range touch these paths?"** (`git log`), while the new code asks **"is the net state of these paths different between the two refs?"** (`git diff`).

These agree for normal commit ranges. They diverge only when a file is changed and then reverted within the range — `git log` would report a change, `git diff` would not. For "should we rebuild this target?" the diff-based answer is arguably more accurate (no rebuild needed if the net state is unchanged), and the existing `emptying a folder does not throw` test exercises exactly this case and continues to pass.

If history-touched semantics are required, the alternative is to batch the original `git log` call. Happy to swap.

## Test plan

- [x] `./gradlew check` — all 9 `ShowServiceChangePluginTest` cases pass plus detekt
- [x] Manually verified: file changes detected; file added-then-reverted reports no change (intended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)