### PR TITLE
Prepare to cut 0.2.2 release

### DIFF
--- a/build-targets-gradle-plugin/build.gradle.kts
+++ b/build-targets-gradle-plugin/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.faire"
-version = "0.2.1"
+version = "0.2.2"
 
 dependencies {
   api(kotlin("stdlib"))


### PR DESCRIPTION
## Summary

Bumps the plugin version from `0.2.1` to `0.2.2` so the fix from #135 (and the dependency bumps merged since `0.2.1`) can be cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)